### PR TITLE
Checked Exceptions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 group = 'io.github.j8spec'
-version = '2.1.0-SNAPSHOT'
+version = '3.0.0-SNAPSHOT'
 ext.isReleaseBuild = !version.endsWith("SNAPSHOT")
 
 sourceCompatibility = '1.8'
@@ -89,7 +89,7 @@ uploadArchives {
                     developer {
                         id 'tprado'
                         name 'Thiago Prado'
-                        email 'tprado@thoughtworks.com'
+                        email 'thiago.gozzi.prado@gmail.com'
                     }
                 }
             }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Jul 25 09:50:19 BRT 2015
+#Thu Feb 18 09:58:43 BRST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-all.zip

--- a/src/main/java/j8spec/BeforeBlock.java
+++ b/src/main/java/j8spec/BeforeBlock.java
@@ -2,20 +2,20 @@ package j8spec;
 
 final class BeforeBlock implements UnsafeBlock {
 
-    private final UnsafeBlock body;
+    private final UnsafeBlock block;
     private final boolean justOnce;
     private boolean onceAlready;
 
-    static BeforeBlock newBeforeAllBlock(UnsafeBlock body) {
-        return new BeforeBlock(body, true);
+    static BeforeBlock newBeforeAllBlock(UnsafeBlock block) {
+        return new BeforeBlock(block, true);
     }
 
-    static BeforeBlock newBeforeEachBlock(UnsafeBlock body) {
-        return new BeforeBlock(body, false);
+    static BeforeBlock newBeforeEachBlock(UnsafeBlock block) {
+        return new BeforeBlock(block, false);
     }
 
-    private BeforeBlock(UnsafeBlock body, boolean justOnce) {
-        this.body = body;
+    private BeforeBlock(UnsafeBlock block, boolean justOnce) {
+        this.block = block;
         this.justOnce = justOnce;
         this.onceAlready = false;
     }
@@ -27,6 +27,6 @@ final class BeforeBlock implements UnsafeBlock {
         }
 
         onceAlready = true;
-        body.tryToExecute();
+        block.tryToExecute();
     }
 }

--- a/src/main/java/j8spec/BeforeBlock.java
+++ b/src/main/java/j8spec/BeforeBlock.java
@@ -21,12 +21,12 @@ final class BeforeBlock implements UnsafeBlock {
     }
 
     @Override
-    public void run() throws Throwable {
+    public void tryToExecute() throws Throwable {
         if (this.justOnce && this.onceAlready) {
             return;
         }
 
         onceAlready = true;
-        body.run();
+        body.tryToExecute();
     }
 }

--- a/src/main/java/j8spec/BeforeBlock.java
+++ b/src/main/java/j8spec/BeforeBlock.java
@@ -1,27 +1,27 @@
 package j8spec;
 
-final class BeforeBlock implements Runnable {
+final class BeforeBlock implements UnsafeBlock {
 
-    private final Runnable body;
+    private final UnsafeBlock body;
     private final boolean justOnce;
     private boolean onceAlready;
 
-    static BeforeBlock newBeforeAllBlock(Runnable body) {
+    static BeforeBlock newBeforeAllBlock(UnsafeBlock body) {
         return new BeforeBlock(body, true);
     }
 
-    static BeforeBlock newBeforeEachBlock(Runnable body) {
+    static BeforeBlock newBeforeEachBlock(UnsafeBlock body) {
         return new BeforeBlock(body, false);
     }
 
-    private BeforeBlock(Runnable body, boolean justOnce) {
+    private BeforeBlock(UnsafeBlock body, boolean justOnce) {
         this.body = body;
         this.justOnce = justOnce;
         this.onceAlready = false;
     }
 
     @Override
-    public void run() {
+    public void run() throws Throwable {
         if (this.justOnce && this.onceAlready) {
             return;
         }

--- a/src/main/java/j8spec/CIModeEnabledException.java
+++ b/src/main/java/j8spec/CIModeEnabledException.java
@@ -2,7 +2,7 @@ package j8spec;
 
 /**
  * Thrown when a method that ignores or focuses a block
- * (like {@link J8Spec#xit(String, Runnable) xit} or {@link J8Spec#fit(String, Runnable) fit})
+ * (like {@link J8Spec#xit(String, UnsafeBlock) xit} or {@link J8Spec#fit(String, UnsafeBlock) fit})
  * is used while the system property <code>j8spec.ci.mode</code> is <code>true</code>.
  * @since 2.0.0
  */

--- a/src/main/java/j8spec/DescribeBlock.java
+++ b/src/main/java/j8spec/DescribeBlock.java
@@ -25,8 +25,8 @@ public final class DescribeBlock {
 
     private final DescribeBlock parent;
     private final String description;
-    private final List<Runnable> beforeAllBlocks;
-    private final List<Runnable> beforeEachBlocks;
+    private final List<UnsafeBlock> beforeAllBlocks;
+    private final List<UnsafeBlock> beforeEachBlocks;
     private final Map<String, ItBlockDefinition> itBlockDefinitions;
     private final List<DescribeBlock> describeBlocks = new LinkedList<>();
     private final Class<?> specClass;
@@ -34,8 +34,8 @@ public final class DescribeBlock {
 
     static DescribeBlock newRootDescribeBlock(
         Class<?> specClass,
-        List<Runnable> beforeAllBlocks,
-        List<Runnable> beforeEachBlocks,
+        List<UnsafeBlock> beforeAllBlocks,
+        List<UnsafeBlock> beforeEachBlocks,
         Map<String, ItBlockDefinition> itBlocks
     ) {
         return new DescribeBlock(specClass, beforeAllBlocks, beforeEachBlocks, itBlocks);
@@ -43,8 +43,8 @@ public final class DescribeBlock {
 
     private DescribeBlock(
         Class<?> specClass,
-        List<Runnable> beforeAllBlocks,
-        List<Runnable> beforeEachBlocks,
+        List<UnsafeBlock> beforeAllBlocks,
+        List<UnsafeBlock> beforeEachBlocks,
         Map<String, ItBlockDefinition> itBlockDefinitions
     ) {
         this.parent = null;
@@ -59,8 +59,8 @@ public final class DescribeBlock {
     private DescribeBlock(
         DescribeBlock parent,
         String description,
-        List<Runnable> beforeAllBlocks,
-        List<Runnable> beforeEachBlocks,
+        List<UnsafeBlock> beforeAllBlocks,
+        List<UnsafeBlock> beforeEachBlocks,
         Map<String, ItBlockDefinition> itBlockDefinitions,
         BlockExecutionFlag executionFlag
     ) {
@@ -75,8 +75,8 @@ public final class DescribeBlock {
 
     DescribeBlock addDescribeBlock(
         String description,
-        List<Runnable> beforeAllBlocks,
-        List<Runnable> beforeEachBlocks,
+        List<UnsafeBlock> beforeAllBlocks,
+        List<UnsafeBlock> beforeEachBlocks,
         Map<String, ItBlockDefinition> itBlocks
     ) {
         DescribeBlock describeBlock = new DescribeBlock(this, description, beforeAllBlocks, beforeEachBlocks, itBlocks, DEFAULT);
@@ -86,8 +86,8 @@ public final class DescribeBlock {
 
     DescribeBlock addIgnoredDescribeBlock(
         String description,
-        List<Runnable> beforeAllBlocks,
-        List<Runnable> beforeEachBlocks,
+        List<UnsafeBlock> beforeAllBlocks,
+        List<UnsafeBlock> beforeEachBlocks,
         Map<String, ItBlockDefinition> itBlocks
     ) {
         DescribeBlock describeBlock = new DescribeBlock(this, description, beforeAllBlocks, beforeEachBlocks, itBlocks, IGNORED);
@@ -97,8 +97,8 @@ public final class DescribeBlock {
 
     DescribeBlock addFocusedDescribeBlock(
         String description,
-        List<Runnable> beforeAllBlocks,
-        List<Runnable> beforeEachBlocks,
+        List<UnsafeBlock> beforeAllBlocks,
+        List<UnsafeBlock> beforeEachBlocks,
         Map<String, ItBlockDefinition> itBlocks
     ) {
         DescribeBlock describeBlock = new DescribeBlock(this, description, beforeAllBlocks, beforeEachBlocks, itBlocks, FOCUSED);
@@ -165,11 +165,11 @@ public final class DescribeBlock {
         return new LinkedList<>(describeBlocks);
     }
 
-    List<Runnable> beforeAllBlocks() {
+    List<UnsafeBlock> beforeAllBlocks() {
         return beforeAllBlocks;
     }
 
-    List<Runnable> beforeEachBlocks() {
+    List<UnsafeBlock> beforeEachBlocks() {
         return beforeEachBlocks;
     }
 

--- a/src/main/java/j8spec/DescribeBlock.java
+++ b/src/main/java/j8spec/DescribeBlock.java
@@ -203,7 +203,7 @@ public final class DescribeBlock {
             if (shouldBeIgnored.test(this, itBlock)) {
                 blocksCollector.add(newIgnoredItBlock(allContainerDescriptions(), description));
             } else {
-                blocksCollector.add(newItBlock(allContainerDescriptions(), description, beforeBlocks, itBlock.body(), itBlock.expected()));
+                blocksCollector.add(newItBlock(allContainerDescriptions(), description, beforeBlocks, itBlock.block(), itBlock.expected()));
             }
         }
 

--- a/src/main/java/j8spec/DescribeBlockDefinition.java
+++ b/src/main/java/j8spec/DescribeBlockDefinition.java
@@ -17,8 +17,8 @@ final class DescribeBlockDefinition {
     private final BlockExecutionFlag executionFlag;
     private final Context<DescribeBlockDefinition> context;
 
-    private final List<Runnable> beforeAllBlocks = new LinkedList<>();
-    private final List<Runnable> beforeEachBlocks = new LinkedList<>();
+    private final List<UnsafeBlock> beforeAllBlocks = new LinkedList<>();
+    private final List<UnsafeBlock> beforeEachBlocks = new LinkedList<>();
     private final Map<String, ItBlockDefinition> itBlockDefinitions = new HashMap<>();
 
     private final List<DescribeBlockDefinition> describeBlockDefinitions = new LinkedList<>();
@@ -54,19 +54,19 @@ final class DescribeBlockDefinition {
         this.context = context;
     }
 
-    void describe(String description, Runnable body) {
+    void describe(String description, SafeBlock body) {
         addDescribe(description, body, DEFAULT);
     }
 
-    void xdescribe(String description, Runnable body) {
+    void xdescribe(String description, SafeBlock body) {
         addDescribe(description, body, IGNORED);
     }
 
-    void fdescribe(String description, Runnable body) {
+    void fdescribe(String description, SafeBlock body) {
         addDescribe(description, body, FOCUSED);
     }
 
-    private void addDescribe(String description, Runnable body, BlockExecutionFlag executionFlag) {
+    private void addDescribe(String description, SafeBlock body, BlockExecutionFlag executionFlag) {
         ensureIsNotAlreadyDefined(
             description,
             describeBlockDefinitions.stream().anyMatch(d -> d.description.equals(description))
@@ -80,11 +80,11 @@ final class DescribeBlockDefinition {
         context.restore();
     }
 
-    void beforeAll(Runnable beforeAllBlock) {
+    void beforeAll(UnsafeBlock beforeAllBlock) {
         this.beforeAllBlocks.add(beforeAllBlock);
     }
 
-    void beforeEach(Runnable beforeEachBlock) {
+    void beforeEach(UnsafeBlock beforeEachBlock) {
         this.beforeEachBlocks.add(beforeEachBlock);
     }
 

--- a/src/main/java/j8spec/DescribeBlockDefinition.java
+++ b/src/main/java/j8spec/DescribeBlockDefinition.java
@@ -54,29 +54,34 @@ final class DescribeBlockDefinition {
         this.context = context;
     }
 
-    void describe(String description, SafeBlock body) {
-        addDescribe(description, body, DEFAULT);
+    void describe(String description, SafeBlock block) {
+        addDescribe(description, block, DEFAULT);
     }
 
-    void xdescribe(String description, SafeBlock body) {
-        addDescribe(description, body, IGNORED);
+    void xdescribe(String description, SafeBlock block) {
+        addDescribe(description, block, IGNORED);
     }
 
-    void fdescribe(String description, SafeBlock body) {
-        addDescribe(description, body, FOCUSED);
+    void fdescribe(String description, SafeBlock block) {
+        addDescribe(description, block, FOCUSED);
     }
 
-    private void addDescribe(String description, SafeBlock body, BlockExecutionFlag executionFlag) {
+    private void addDescribe(String description, SafeBlock block, BlockExecutionFlag executionFlag) {
         ensureIsNotAlreadyDefined(
             description,
             describeBlockDefinitions.stream().anyMatch(d -> d.description.equals(description))
         );
 
-        DescribeBlockDefinition block = new DescribeBlockDefinition(specClass, description, executionFlag, context);
-        describeBlockDefinitions.add(block);
+        DescribeBlockDefinition describeBlockDefinition = new DescribeBlockDefinition(
+            specClass,
+            description,
+            executionFlag,
+            context
+        );
+        describeBlockDefinitions.add(describeBlockDefinition);
 
-        context.switchTo(block);
-        body.execute();
+        context.switchTo(describeBlockDefinition);
+        block.execute();
         context.restore();
     }
 

--- a/src/main/java/j8spec/DescribeBlockDefinition.java
+++ b/src/main/java/j8spec/DescribeBlockDefinition.java
@@ -76,7 +76,7 @@ final class DescribeBlockDefinition {
         describeBlockDefinitions.add(block);
 
         context.switchTo(block);
-        body.run();
+        body.execute();
         context.restore();
     }
 

--- a/src/main/java/j8spec/ItBlock.java
+++ b/src/main/java/j8spec/ItBlock.java
@@ -9,21 +9,19 @@ import static java.util.Collections.unmodifiableList;
  * Representation of a "it" block ready to be executed.
  * @since 1.0.0
  */
-public final class ItBlock implements Runnable {
-
-    private static final Runnable NOOP = () -> {};
+public final class ItBlock implements UnsafeBlock {
 
     private final List<String> containerDescriptions;
     private final String description;
     private final List<BeforeBlock> beforeBlocks;
-    private final Runnable body;
+    private final UnsafeBlock body;
     private final Class<? extends Throwable> expectedException;
 
     static ItBlock newItBlock(
         List<String> containerDescriptions,
         String description,
         List<BeforeBlock> beforeBlocks,
-        Runnable body
+        UnsafeBlock body
     ) {
         return new ItBlock(containerDescriptions, description, beforeBlocks, body, null);
     }
@@ -32,7 +30,7 @@ public final class ItBlock implements Runnable {
         List<String> containerDescriptions,
         String description,
         List<BeforeBlock> beforeBlocks,
-        Runnable body,
+        UnsafeBlock body,
         Class<? extends Throwable> expectedException
     ) {
         return new ItBlock(containerDescriptions, description, beforeBlocks, body, expectedException);
@@ -46,7 +44,7 @@ public final class ItBlock implements Runnable {
         List<String> containerDescriptions,
         String description,
         List<BeforeBlock> beforeBlocks,
-        Runnable body,
+        UnsafeBlock body,
         Class<? extends Throwable> expectedException
     ) {
         this.containerDescriptions = unmodifiableList(containerDescriptions);
@@ -77,8 +75,10 @@ public final class ItBlock implements Runnable {
      * @since 2.0.0
      */
     @Override
-    public void run() {
-        beforeBlocks.forEach(Runnable::run);
+    public void run() throws Throwable {
+        for (BeforeBlock beforeBlock : beforeBlocks) {
+            beforeBlock.run();
+        }
         body.run();
     }
 

--- a/src/main/java/j8spec/ItBlock.java
+++ b/src/main/java/j8spec/ItBlock.java
@@ -75,11 +75,11 @@ public final class ItBlock implements UnsafeBlock {
      * @since 2.0.0
      */
     @Override
-    public void run() throws Throwable {
+    public void tryToExecute() throws Throwable {
         for (BeforeBlock beforeBlock : beforeBlocks) {
-            beforeBlock.run();
+            beforeBlock.tryToExecute();
         }
-        body.run();
+        body.tryToExecute();
     }
 
     /**

--- a/src/main/java/j8spec/ItBlock.java
+++ b/src/main/java/j8spec/ItBlock.java
@@ -14,26 +14,26 @@ public final class ItBlock implements UnsafeBlock {
     private final List<String> containerDescriptions;
     private final String description;
     private final List<BeforeBlock> beforeBlocks;
-    private final UnsafeBlock body;
+    private final UnsafeBlock block;
     private final Class<? extends Throwable> expectedException;
 
     static ItBlock newItBlock(
         List<String> containerDescriptions,
         String description,
         List<BeforeBlock> beforeBlocks,
-        UnsafeBlock body
+        UnsafeBlock block
     ) {
-        return new ItBlock(containerDescriptions, description, beforeBlocks, body, null);
+        return new ItBlock(containerDescriptions, description, beforeBlocks, block, null);
     }
 
     static ItBlock newItBlock(
         List<String> containerDescriptions,
         String description,
         List<BeforeBlock> beforeBlocks,
-        UnsafeBlock body,
+        UnsafeBlock block,
         Class<? extends Throwable> expectedException
     ) {
-        return new ItBlock(containerDescriptions, description, beforeBlocks, body, expectedException);
+        return new ItBlock(containerDescriptions, description, beforeBlocks, block, expectedException);
     }
 
     static ItBlock newIgnoredItBlock(List<String> containerDescriptions, String description) {
@@ -44,13 +44,13 @@ public final class ItBlock implements UnsafeBlock {
         List<String> containerDescriptions,
         String description,
         List<BeforeBlock> beforeBlocks,
-        UnsafeBlock body,
+        UnsafeBlock block,
         Class<? extends Throwable> expectedException
     ) {
         this.containerDescriptions = unmodifiableList(containerDescriptions);
         this.description = description;
         this.beforeBlocks = unmodifiableList(beforeBlocks);
-        this.body = body;
+        this.block = block;
         this.expectedException = expectedException;
     }
 
@@ -79,7 +79,7 @@ public final class ItBlock implements UnsafeBlock {
         for (BeforeBlock beforeBlock : beforeBlocks) {
             beforeBlock.tryToExecute();
         }
-        body.tryToExecute();
+        block.tryToExecute();
     }
 
     /**
@@ -87,7 +87,7 @@ public final class ItBlock implements UnsafeBlock {
      * @since 2.0.0
      */
     public boolean shouldBeIgnored() {
-        return body == NOOP;
+        return block == NOOP;
     }
 
     /**

--- a/src/main/java/j8spec/ItBlockConfiguration.java
+++ b/src/main/java/j8spec/ItBlockConfiguration.java
@@ -6,7 +6,7 @@ package j8spec;
  */
 public final class ItBlockConfiguration {
 
-    private Runnable body;
+    private UnsafeBlock body;
     private Class<? extends Throwable> expectedException;
 
     static ItBlockConfiguration newItBlockConfiguration() {
@@ -27,7 +27,7 @@ public final class ItBlockConfiguration {
         return this;
     }
 
-    ItBlockConfiguration body(Runnable body) {
+    ItBlockConfiguration body(UnsafeBlock body) {
         this.body = body;
         return this;
     }

--- a/src/main/java/j8spec/ItBlockConfiguration.java
+++ b/src/main/java/j8spec/ItBlockConfiguration.java
@@ -6,7 +6,7 @@ package j8spec;
  */
 public final class ItBlockConfiguration {
 
-    private UnsafeBlock body;
+    private UnsafeBlock block;
     private Class<? extends Throwable> expectedException;
 
     static ItBlockConfiguration newItBlockConfiguration() {
@@ -27,20 +27,20 @@ public final class ItBlockConfiguration {
         return this;
     }
 
-    ItBlockConfiguration body(UnsafeBlock body) {
-        this.body = body;
+    ItBlockConfiguration block(UnsafeBlock block) {
+        this.block = block;
         return this;
     }
 
     ItBlockDefinition newItBlockDefinition() {
-        return ItBlockDefinition.newItBlockDefinition(body, expectedException);
+        return ItBlockDefinition.newItBlockDefinition(block, expectedException);
     }
 
     ItBlockDefinition newIgnoredItBlockDefinition() {
-        return ItBlockDefinition.newIgnoredItBlockDefinition(body, expectedException);
+        return ItBlockDefinition.newIgnoredItBlockDefinition(block, expectedException);
     }
 
     ItBlockDefinition newFocusedItBlockDefinition() {
-        return ItBlockDefinition.newFocusedItBlockDefinition(body, expectedException);
+        return ItBlockDefinition.newFocusedItBlockDefinition(block, expectedException);
     }
 }

--- a/src/main/java/j8spec/ItBlockDefinition.java
+++ b/src/main/java/j8spec/ItBlockDefinition.java
@@ -6,42 +6,42 @@ import static j8spec.BlockExecutionFlag.IGNORED;
 
 final class ItBlockDefinition {
 
-    private final UnsafeBlock body;
+    private final UnsafeBlock block;
     private final BlockExecutionFlag executionFlag;
     private final Class<? extends Throwable> expectedException;
 
-    static ItBlockDefinition newItBlockDefinition(UnsafeBlock body) {
-        return new ItBlockDefinition(body, DEFAULT, null);
+    static ItBlockDefinition newItBlockDefinition(UnsafeBlock block) {
+        return new ItBlockDefinition(block, DEFAULT, null);
     }
 
-    static ItBlockDefinition newItBlockDefinition(UnsafeBlock body, Class<? extends Throwable> expectedException) {
-        return new ItBlockDefinition(body, DEFAULT, expectedException);
+    static ItBlockDefinition newItBlockDefinition(UnsafeBlock block, Class<? extends Throwable> expectedException) {
+        return new ItBlockDefinition(block, DEFAULT, expectedException);
     }
 
-    static ItBlockDefinition newIgnoredItBlockDefinition(UnsafeBlock body) {
-        return new ItBlockDefinition(body, IGNORED, null);
+    static ItBlockDefinition newIgnoredItBlockDefinition(UnsafeBlock block) {
+        return new ItBlockDefinition(block, IGNORED, null);
     }
 
-    static ItBlockDefinition newIgnoredItBlockDefinition(UnsafeBlock body, Class<? extends Throwable> expectedException) {
-        return new ItBlockDefinition(body, IGNORED, expectedException);
+    static ItBlockDefinition newIgnoredItBlockDefinition(UnsafeBlock block, Class<? extends Throwable> expectedException) {
+        return new ItBlockDefinition(block, IGNORED, expectedException);
     }
 
-    static ItBlockDefinition newFocusedItBlockDefinition(UnsafeBlock body) {
-        return new ItBlockDefinition(body, FOCUSED, null);
+    static ItBlockDefinition newFocusedItBlockDefinition(UnsafeBlock block) {
+        return new ItBlockDefinition(block, FOCUSED, null);
     }
 
-    static ItBlockDefinition newFocusedItBlockDefinition(UnsafeBlock body, Class<? extends Throwable> expectedException) {
-        return new ItBlockDefinition(body, FOCUSED, expectedException);
+    static ItBlockDefinition newFocusedItBlockDefinition(UnsafeBlock block, Class<? extends Throwable> expectedException) {
+        return new ItBlockDefinition(block, FOCUSED, expectedException);
     }
 
-    private ItBlockDefinition(UnsafeBlock body, BlockExecutionFlag executionFlag, Class<? extends Throwable> expectedException) {
-        this.body = body;
+    private ItBlockDefinition(UnsafeBlock block, BlockExecutionFlag executionFlag, Class<? extends Throwable> expectedException) {
+        this.block = block;
         this.executionFlag = executionFlag;
         this.expectedException = expectedException;
     }
 
-    UnsafeBlock body() {
-        return body;
+    UnsafeBlock block() {
+        return block;
     }
 
     boolean ignored() {

--- a/src/main/java/j8spec/ItBlockDefinition.java
+++ b/src/main/java/j8spec/ItBlockDefinition.java
@@ -6,41 +6,41 @@ import static j8spec.BlockExecutionFlag.IGNORED;
 
 final class ItBlockDefinition {
 
-    private final Runnable body;
+    private final UnsafeBlock body;
     private final BlockExecutionFlag executionFlag;
     private final Class<? extends Throwable> expectedException;
 
-    static ItBlockDefinition newItBlockDefinition(Runnable body) {
+    static ItBlockDefinition newItBlockDefinition(UnsafeBlock body) {
         return new ItBlockDefinition(body, DEFAULT, null);
     }
 
-    static ItBlockDefinition newItBlockDefinition(Runnable body, Class<? extends Throwable> expectedException) {
+    static ItBlockDefinition newItBlockDefinition(UnsafeBlock body, Class<? extends Throwable> expectedException) {
         return new ItBlockDefinition(body, DEFAULT, expectedException);
     }
 
-    static ItBlockDefinition newIgnoredItBlockDefinition(Runnable body) {
+    static ItBlockDefinition newIgnoredItBlockDefinition(UnsafeBlock body) {
         return new ItBlockDefinition(body, IGNORED, null);
     }
 
-    static ItBlockDefinition newIgnoredItBlockDefinition(Runnable body, Class<? extends Throwable> expectedException) {
+    static ItBlockDefinition newIgnoredItBlockDefinition(UnsafeBlock body, Class<? extends Throwable> expectedException) {
         return new ItBlockDefinition(body, IGNORED, expectedException);
     }
 
-    static ItBlockDefinition newFocusedItBlockDefinition(Runnable body) {
+    static ItBlockDefinition newFocusedItBlockDefinition(UnsafeBlock body) {
         return new ItBlockDefinition(body, FOCUSED, null);
     }
 
-    static ItBlockDefinition newFocusedItBlockDefinition(Runnable body, Class<? extends Throwable> expectedException) {
+    static ItBlockDefinition newFocusedItBlockDefinition(UnsafeBlock body, Class<? extends Throwable> expectedException) {
         return new ItBlockDefinition(body, FOCUSED, expectedException);
     }
 
-    private ItBlockDefinition(Runnable body, BlockExecutionFlag executionFlag, Class<? extends Throwable> expectedException) {
+    private ItBlockDefinition(UnsafeBlock body, BlockExecutionFlag executionFlag, Class<? extends Throwable> expectedException) {
         this.body = body;
         this.executionFlag = executionFlag;
         this.expectedException = expectedException;
     }
 
-    Runnable body() {
+    UnsafeBlock body() {
         return body;
     }
 

--- a/src/main/java/j8spec/J8Spec.java
+++ b/src/main/java/j8spec/J8Spec.java
@@ -23,39 +23,39 @@ public final class J8Spec {
      * Defines a new "describe" block.
      *
      * @param description textual description of the new block
-     * @param body code that defines inner blocks, like "describe", "it", etc - this code is executed
+     * @param block code that defines inner blocks, like "describe", "it", etc - this code is executed
      *             immediately
      * @throws IllegalContextException if called outside the context of the {@link #read(Class)} method
      * @throws BlockAlreadyDefinedException if another block with the same description in the same context has been
      * defined already
      * @since 1.0.0
      */
-    public static synchronized void describe(String description, SafeBlock body) {
+    public static synchronized void describe(String description, SafeBlock block) {
         isValidContext("describe");
-        contexts.get().current().describe(description, body);
+        contexts.get().current().describe(description, block);
     }
 
     /**
      * Alias for {@link #describe(String, SafeBlock)}.
      *
      * @param description textual description of the new block
-     * @param body code that defines inner blocks, like "describe", "it", etc - this code is executed
+     * @param block code that defines inner blocks, like "describe", "it", etc - this code is executed
      *             immediately
      * @throws IllegalContextException if called outside the context of the {@link #read(Class)} method
      * @throws BlockAlreadyDefinedException if another block with the same description in the same context has been
      * defined already
      * @since 2.0.0
      */
-    public static synchronized void context(String description, SafeBlock body) {
+    public static synchronized void context(String description, SafeBlock block) {
         isValidContext("context");
-        contexts.get().current().describe(description, body);
+        contexts.get().current().describe(description, block);
     }
 
     /**
      * Defines a new ignored "describe" block.
      *
      * @param description textual description of the new block
-     * @param body code that defines inner blocks, like "describe", "it", etc - this code is executed
+     * @param block code that defines inner blocks, like "describe", "it", etc - this code is executed
      *             immediately
      * @throws IllegalContextException if called outside the context of the {@link #read(Class)} method
      * @throws BlockAlreadyDefinedException if another block with the same description in the same context has been
@@ -63,17 +63,17 @@ public final class J8Spec {
      * @throws CIModeEnabledException if the system property <code>j8spec.ci.mode</code> is <code>true</code>
      * @since 2.0.0
      */
-    public static synchronized void xdescribe(String description, SafeBlock body) {
+    public static synchronized void xdescribe(String description, SafeBlock block) {
         notAllowedWhenCIModeEnabled("xdescribe");
         isValidContext("xdescribe");
-        contexts.get().current().xdescribe(description, body);
+        contexts.get().current().xdescribe(description, block);
     }
 
     /**
      * Alias for {@link #xdescribe(String, SafeBlock)}.
      *
      * @param description textual description of the new block
-     * @param body code that defines inner blocks, like "describe", "it", etc - this code is executed
+     * @param block code that defines inner blocks, like "describe", "it", etc - this code is executed
      *             immediately
      * @throws IllegalContextException if called outside the context of the {@link #read(Class)} method
      * @throws BlockAlreadyDefinedException if another block with the same description in the same context has been
@@ -81,17 +81,17 @@ public final class J8Spec {
      * @throws CIModeEnabledException if the system property <code>j8spec.ci.mode</code> is <code>true</code>
      * @since 2.0.0
      */
-    public static synchronized void xcontext(String description, SafeBlock body) {
+    public static synchronized void xcontext(String description, SafeBlock block) {
         notAllowedWhenCIModeEnabled("xcontext");
         isValidContext("xcontext");
-        contexts.get().current().xdescribe(description, body);
+        contexts.get().current().xdescribe(description, block);
     }
 
     /**
      * Defines a new focused "describe" block.
      *
      * @param description textual description of the new block
-     * @param body code that defines inner blocks, like "describe", "it", etc - this code is executed
+     * @param block code that defines inner blocks, like "describe", "it", etc - this code is executed
      *             immediately
      * @throws IllegalContextException if called outside the context of the {@link #read(Class)} method
      * @throws BlockAlreadyDefinedException if another block with the same description in the same context has been
@@ -99,17 +99,17 @@ public final class J8Spec {
      * @throws CIModeEnabledException if the system property <code>j8spec.ci.mode</code> is <code>true</code>
      * @since 2.0.0
      */
-    public static synchronized void fdescribe(String description, SafeBlock body) {
+    public static synchronized void fdescribe(String description, SafeBlock block) {
         notAllowedWhenCIModeEnabled("fdescribe");
         isValidContext("fdescribe");
-        contexts.get().current().fdescribe(description, body);
+        contexts.get().current().fdescribe(description, block);
     }
 
     /**
      * Alias for {@link #fdescribe(String, SafeBlock)}.
      *
      * @param description textual description of the new block
-     * @param body code that defines inner blocks, like "describe", "it", etc - this code is executed
+     * @param block code that defines inner blocks, like "describe", "it", etc - this code is executed
      *             immediately
      * @throws IllegalContextException if called outside the context of the {@link #read(Class)} method
      * @throws BlockAlreadyDefinedException if another block with the same description in the same context has been
@@ -117,48 +117,48 @@ public final class J8Spec {
      * @throws CIModeEnabledException if the system property <code>j8spec.ci.mode</code> is <code>true</code>
      * @since 2.0.0
      */
-    public static synchronized void fcontext(String description, SafeBlock body) {
+    public static synchronized void fcontext(String description, SafeBlock block) {
         notAllowedWhenCIModeEnabled("fcontext");
         isValidContext("fcontext");
-        contexts.get().current().fdescribe(description, body);
+        contexts.get().current().fdescribe(description, block);
     }
 
     /**
      * Defines a new "before all" block.
      *
-     * @param body code to be executed before all "it" blocks
+     * @param block code to be executed before all "it" blocks
      * @throws IllegalContextException if called outside the context of the {@link #read(Class)} method
      * @since 2.0.0
      */
-    public static synchronized void beforeAll(UnsafeBlock body) {
+    public static synchronized void beforeAll(UnsafeBlock block) {
         isValidContext("beforeAll");
-        contexts.get().current().beforeAll(body);
+        contexts.get().current().beforeAll(block);
     }
 
     /**
      * Defines a new "before each" block.
      *
-     * @param body code to be executed before each "it" block
+     * @param block code to be executed before each "it" block
      * @throws IllegalContextException if called outside the context of the {@link #read(Class)} method
      * @since 1.0.0
      */
-    public static synchronized void beforeEach(UnsafeBlock body) {
+    public static synchronized void beforeEach(UnsafeBlock block) {
         isValidContext("beforeEach");
-        contexts.get().current().beforeEach(body);
+        contexts.get().current().beforeEach(block);
     }
 
     /**
      * Defines a new "it" block.
      *
      * @param description textual description of the new block
-     * @param body code to be executed
+     * @param block code to be executed
      * @throws IllegalContextException if called outside the context of the {@link #read(Class)} method
      * @throws BlockAlreadyDefinedException if another block with the same description in the same context has been
      * defined already
      * @since 1.0.0
      */
-    public static synchronized void it(String description, UnsafeBlock body) {
-        it(description, identity(), body);
+    public static synchronized void it(String description, UnsafeBlock block) {
+        it(description, identity(), block);
     }
 
     /**
@@ -166,7 +166,7 @@ public final class J8Spec {
      *
      * @param description textual description of the new block
      * @param collector block configuration collector
-     * @param body code to be executed
+     * @param block code to be executed
      * @throws IllegalContextException if called outside the context of the {@link #read(Class)} method
      * @throws BlockAlreadyDefinedException if another block with the same description in the same context has been
      * defined already
@@ -175,11 +175,11 @@ public final class J8Spec {
     public static synchronized void it(
         String description,
         Function<ItBlockConfiguration, ItBlockConfiguration> collector,
-        UnsafeBlock body
+        UnsafeBlock block
     ) {
         isValidContext("it");
         ItBlockDefinition itBlockDefinition = collector.apply(newItBlockConfiguration())
-            .body(body)
+            .block(block)
             .newItBlockDefinition();
         contexts.get().current().it(description, itBlockDefinition);
     }
@@ -188,15 +188,15 @@ public final class J8Spec {
      * Defines a new ignored "it" block.
      *
      * @param description textual description of the new block
-     * @param body code to be executed
+     * @param block code to be executed
      * @throws IllegalContextException if called outside the context of the {@link #read(Class)} method
      * @throws BlockAlreadyDefinedException if another block with the same description in the same context has been
      * defined already
      * @throws CIModeEnabledException if the system property <code>j8spec.ci.mode</code> is <code>true</code>
      * @since 2.0.0
      */
-    public static synchronized void xit(String description, UnsafeBlock body) {
-        xit(description, identity(), body);
+    public static synchronized void xit(String description, UnsafeBlock block) {
+        xit(description, identity(), block);
     }
 
     /**
@@ -204,7 +204,7 @@ public final class J8Spec {
      *
      * @param description textual description of the new block
      * @param collector block configuration collector
-     * @param body code to be executed
+     * @param block code to be executed
      * @throws IllegalContextException if called outside the context of the {@link #read(Class)} method
      * @throws BlockAlreadyDefinedException if another block with the same description in the same context has been
      * defined already
@@ -214,12 +214,12 @@ public final class J8Spec {
     public static synchronized void xit(
         String description,
         Function<ItBlockConfiguration, ItBlockConfiguration> collector,
-        UnsafeBlock body
+        UnsafeBlock block
     ) {
         notAllowedWhenCIModeEnabled("xit");
         isValidContext("xit");
         ItBlockDefinition itBlockDefinition = collector.apply(newItBlockConfiguration())
-            .body(body)
+            .block(block)
             .newIgnoredItBlockDefinition();
         contexts.get().current().it(description, itBlockDefinition);
     }
@@ -228,15 +228,15 @@ public final class J8Spec {
      * Defines a new focused "it" block.
      *
      * @param description textual description of the new block
-     * @param body code to be executed
+     * @param block code to be executed
      * @throws IllegalContextException if called outside the context of the {@link #read(Class)} method
      * @throws BlockAlreadyDefinedException if another block with the same description in the same context has been
      * defined already
      * @throws CIModeEnabledException if the system property <code>j8spec.ci.mode</code> is <code>true</code>
      * @since 2.0.0
      */
-    public static synchronized void fit(String description, UnsafeBlock body) {
-        fit(description, identity(), body);
+    public static synchronized void fit(String description, UnsafeBlock block) {
+        fit(description, identity(), block);
     }
 
     /**
@@ -244,7 +244,7 @@ public final class J8Spec {
      *
      * @param description textual description of the new block
      * @param collector block configuration collector
-     * @param body code to be executed
+     * @param block code to be executed
      * @throws IllegalContextException if called outside the context of the {@link #read(Class)} method
      * @throws BlockAlreadyDefinedException if another block with the same description in the same context has been
      * defined already
@@ -254,12 +254,12 @@ public final class J8Spec {
     public static synchronized void fit(
         String description,
         Function<ItBlockConfiguration, ItBlockConfiguration> collector,
-        UnsafeBlock body
+        UnsafeBlock block
     ) {
         notAllowedWhenCIModeEnabled("fit");
         isValidContext("fit");
         ItBlockDefinition itBlockDefinition = collector.apply(newItBlockConfiguration())
-            .body(body)
+            .block(block)
             .newFocusedItBlockDefinition();
         contexts.get().current().it(description, itBlockDefinition);
     }

--- a/src/main/java/j8spec/J8Spec.java
+++ b/src/main/java/j8spec/J8Spec.java
@@ -30,13 +30,13 @@ public final class J8Spec {
      * defined already
      * @since 1.0.0
      */
-    public static synchronized void describe(String description, Runnable body) {
+    public static synchronized void describe(String description, SafeBlock body) {
         isValidContext("describe");
         contexts.get().current().describe(description, body);
     }
 
     /**
-     * Alias for {@link #describe(String, Runnable)}.
+     * Alias for {@link #describe(String, SafeBlock)}.
      *
      * @param description textual description of the new block
      * @param body code that defines inner blocks, like "describe", "it", etc - this code is executed
@@ -46,7 +46,7 @@ public final class J8Spec {
      * defined already
      * @since 2.0.0
      */
-    public static synchronized void context(String description, Runnable body) {
+    public static synchronized void context(String description, SafeBlock body) {
         isValidContext("context");
         contexts.get().current().describe(description, body);
     }
@@ -63,14 +63,14 @@ public final class J8Spec {
      * @throws CIModeEnabledException if the system property <code>j8spec.ci.mode</code> is <code>true</code>
      * @since 2.0.0
      */
-    public static synchronized void xdescribe(String description, Runnable body) {
+    public static synchronized void xdescribe(String description, SafeBlock body) {
         notAllowedWhenCIModeEnabled("xdescribe");
         isValidContext("xdescribe");
         contexts.get().current().xdescribe(description, body);
     }
 
     /**
-     * Alias for {@link #xdescribe(String, Runnable)}.
+     * Alias for {@link #xdescribe(String, SafeBlock)}.
      *
      * @param description textual description of the new block
      * @param body code that defines inner blocks, like "describe", "it", etc - this code is executed
@@ -81,7 +81,7 @@ public final class J8Spec {
      * @throws CIModeEnabledException if the system property <code>j8spec.ci.mode</code> is <code>true</code>
      * @since 2.0.0
      */
-    public static synchronized void xcontext(String description, Runnable body) {
+    public static synchronized void xcontext(String description, SafeBlock body) {
         notAllowedWhenCIModeEnabled("xcontext");
         isValidContext("xcontext");
         contexts.get().current().xdescribe(description, body);
@@ -99,14 +99,14 @@ public final class J8Spec {
      * @throws CIModeEnabledException if the system property <code>j8spec.ci.mode</code> is <code>true</code>
      * @since 2.0.0
      */
-    public static synchronized void fdescribe(String description, Runnable body) {
+    public static synchronized void fdescribe(String description, SafeBlock body) {
         notAllowedWhenCIModeEnabled("fdescribe");
         isValidContext("fdescribe");
         contexts.get().current().fdescribe(description, body);
     }
 
     /**
-     * Alias for {@link #fdescribe(String, Runnable)}.
+     * Alias for {@link #fdescribe(String, SafeBlock)}.
      *
      * @param description textual description of the new block
      * @param body code that defines inner blocks, like "describe", "it", etc - this code is executed
@@ -117,7 +117,7 @@ public final class J8Spec {
      * @throws CIModeEnabledException if the system property <code>j8spec.ci.mode</code> is <code>true</code>
      * @since 2.0.0
      */
-    public static synchronized void fcontext(String description, Runnable body) {
+    public static synchronized void fcontext(String description, SafeBlock body) {
         notAllowedWhenCIModeEnabled("fcontext");
         isValidContext("fcontext");
         contexts.get().current().fdescribe(description, body);
@@ -130,7 +130,7 @@ public final class J8Spec {
      * @throws IllegalContextException if called outside the context of the {@link #read(Class)} method
      * @since 2.0.0
      */
-    public static synchronized void beforeAll(Runnable body) {
+    public static synchronized void beforeAll(UnsafeBlock body) {
         isValidContext("beforeAll");
         contexts.get().current().beforeAll(body);
     }
@@ -142,7 +142,7 @@ public final class J8Spec {
      * @throws IllegalContextException if called outside the context of the {@link #read(Class)} method
      * @since 1.0.0
      */
-    public static synchronized void beforeEach(Runnable body) {
+    public static synchronized void beforeEach(UnsafeBlock body) {
         isValidContext("beforeEach");
         contexts.get().current().beforeEach(body);
     }
@@ -157,7 +157,7 @@ public final class J8Spec {
      * defined already
      * @since 1.0.0
      */
-    public static synchronized void it(String description, Runnable body) {
+    public static synchronized void it(String description, UnsafeBlock body) {
         it(description, identity(), body);
     }
 
@@ -175,7 +175,7 @@ public final class J8Spec {
     public static synchronized void it(
         String description,
         Function<ItBlockConfiguration, ItBlockConfiguration> collector,
-        Runnable body
+        UnsafeBlock body
     ) {
         isValidContext("it");
         ItBlockDefinition itBlockDefinition = collector.apply(newItBlockConfiguration())
@@ -195,7 +195,7 @@ public final class J8Spec {
      * @throws CIModeEnabledException if the system property <code>j8spec.ci.mode</code> is <code>true</code>
      * @since 2.0.0
      */
-    public static synchronized void xit(String description, Runnable body) {
+    public static synchronized void xit(String description, UnsafeBlock body) {
         xit(description, identity(), body);
     }
 
@@ -214,7 +214,7 @@ public final class J8Spec {
     public static synchronized void xit(
         String description,
         Function<ItBlockConfiguration, ItBlockConfiguration> collector,
-        Runnable body
+        UnsafeBlock body
     ) {
         notAllowedWhenCIModeEnabled("xit");
         isValidContext("xit");
@@ -235,7 +235,7 @@ public final class J8Spec {
      * @throws CIModeEnabledException if the system property <code>j8spec.ci.mode</code> is <code>true</code>
      * @since 2.0.0
      */
-    public static synchronized void fit(String description, Runnable body) {
+    public static synchronized void fit(String description, UnsafeBlock body) {
         fit(description, identity(), body);
     }
 
@@ -254,7 +254,7 @@ public final class J8Spec {
     public static synchronized void fit(
         String description,
         Function<ItBlockConfiguration, ItBlockConfiguration> collector,
-        Runnable body
+        UnsafeBlock body
     ) {
         notAllowedWhenCIModeEnabled("fit");
         isValidContext("fit");

--- a/src/main/java/j8spec/SafeBlock.java
+++ b/src/main/java/j8spec/SafeBlock.java
@@ -1,6 +1,8 @@
 package j8spec;
 
 /**
+ * Block of code that is safe to execute, i.e. it does not throw checked exceptions.
+ *
  * @see j8spec.UnsafeBlock
  * @since 3.0.0
  */
@@ -9,5 +11,8 @@ public interface SafeBlock {
 
     SafeBlock NOOP = () -> {};
 
+    /**
+     * Execute the block of code.
+     */
     void execute();
 }

--- a/src/main/java/j8spec/SafeBlock.java
+++ b/src/main/java/j8spec/SafeBlock.java
@@ -1,6 +1,7 @@
 package j8spec;
 
 /**
+ * @see j8spec.UnsafeBlock
  * @since 3.0.0
  */
 @FunctionalInterface
@@ -8,5 +9,5 @@ public interface SafeBlock {
 
     SafeBlock NOOP = () -> {};
 
-    void run();
+    void execute();
 }

--- a/src/main/java/j8spec/SafeBlock.java
+++ b/src/main/java/j8spec/SafeBlock.java
@@ -1,0 +1,12 @@
+package j8spec;
+
+/**
+ * @since 3.0.0
+ */
+@FunctionalInterface
+public interface SafeBlock {
+
+    SafeBlock NOOP = () -> {};
+
+    void run();
+}

--- a/src/main/java/j8spec/UnsafeBlock.java
+++ b/src/main/java/j8spec/UnsafeBlock.java
@@ -1,6 +1,8 @@
 package j8spec;
 
 /**
+ * Block of code that is unsafe to execute, i.e. it could throw checked exceptions.
+ *
  * @see j8spec.SafeBlock
  * @since 3.0.0
  */
@@ -9,5 +11,10 @@ public interface UnsafeBlock {
 
     UnsafeBlock NOOP = () -> {};
 
+    /**
+     * Try to execute the block of code.
+     *
+     * @throws Throwable if unable to execute the block of code
+     */
     void tryToExecute() throws Throwable;
 }

--- a/src/main/java/j8spec/UnsafeBlock.java
+++ b/src/main/java/j8spec/UnsafeBlock.java
@@ -1,6 +1,7 @@
 package j8spec;
 
 /**
+ * @see j8spec.SafeBlock
  * @since 3.0.0
  */
 @FunctionalInterface
@@ -8,5 +9,5 @@ public interface UnsafeBlock {
 
     UnsafeBlock NOOP = () -> {};
 
-    void run() throws Throwable;
+    void tryToExecute() throws Throwable;
 }

--- a/src/main/java/j8spec/UnsafeBlock.java
+++ b/src/main/java/j8spec/UnsafeBlock.java
@@ -1,0 +1,12 @@
+package j8spec;
+
+/**
+ * @since 3.0.0
+ */
+@FunctionalInterface
+public interface UnsafeBlock {
+
+    UnsafeBlock NOOP = () -> {};
+
+    void run() throws Throwable;
+}

--- a/src/main/java/j8spec/junit/ItBlockStatement.java
+++ b/src/main/java/j8spec/junit/ItBlockStatement.java
@@ -24,6 +24,6 @@ final class ItBlockStatement extends Statement {
 
     @Override
     public void evaluate() throws Throwable {
-        itBlock.run();
+        itBlock.tryToExecute();
     }
 }

--- a/src/test/java/j8spec/BeforeBlockTest.java
+++ b/src/test/java/j8spec/BeforeBlockTest.java
@@ -7,24 +7,24 @@ import static org.mockito.Mockito.*;
 public class BeforeBlockTest {
 
     @Test
-    public void runs_given_body_only_once() throws Throwable {
-        UnsafeBlock body = mock(UnsafeBlock.class);
-        BeforeBlock beforeBlock = BeforeBlock.newBeforeAllBlock(body);
+    public void runs_given_block_only_once() throws Throwable {
+        UnsafeBlock block = mock(UnsafeBlock.class);
+        BeforeBlock beforeBlock = BeforeBlock.newBeforeAllBlock(block);
 
         beforeBlock.tryToExecute();
         beforeBlock.tryToExecute();
 
-        verify(body, times(1)).tryToExecute();
+        verify(block, times(1)).tryToExecute();
     }
 
     @Test
-    public void runs_given_body_on_each_call() throws Throwable {
-        UnsafeBlock body = mock(UnsafeBlock.class);
-        BeforeBlock beforeBlock = BeforeBlock.newBeforeEachBlock(body);
+    public void runs_given_block_on_each_call() throws Throwable {
+        UnsafeBlock block = mock(UnsafeBlock.class);
+        BeforeBlock beforeBlock = BeforeBlock.newBeforeEachBlock(block);
 
         beforeBlock.tryToExecute();
         beforeBlock.tryToExecute();
 
-        verify(body, times(2)).tryToExecute();
+        verify(block, times(2)).tryToExecute();
     }
 }

--- a/src/test/java/j8spec/BeforeBlockTest.java
+++ b/src/test/java/j8spec/BeforeBlockTest.java
@@ -11,10 +11,10 @@ public class BeforeBlockTest {
         UnsafeBlock body = mock(UnsafeBlock.class);
         BeforeBlock beforeBlock = BeforeBlock.newBeforeAllBlock(body);
 
-        beforeBlock.run();
-        beforeBlock.run();
+        beforeBlock.tryToExecute();
+        beforeBlock.tryToExecute();
 
-        verify(body, times(1)).run();
+        verify(body, times(1)).tryToExecute();
     }
 
     @Test
@@ -22,9 +22,9 @@ public class BeforeBlockTest {
         UnsafeBlock body = mock(UnsafeBlock.class);
         BeforeBlock beforeBlock = BeforeBlock.newBeforeEachBlock(body);
 
-        beforeBlock.run();
-        beforeBlock.run();
+        beforeBlock.tryToExecute();
+        beforeBlock.tryToExecute();
 
-        verify(body, times(2)).run();
+        verify(body, times(2)).tryToExecute();
     }
 }

--- a/src/test/java/j8spec/BeforeBlockTest.java
+++ b/src/test/java/j8spec/BeforeBlockTest.java
@@ -7,8 +7,8 @@ import static org.mockito.Mockito.*;
 public class BeforeBlockTest {
 
     @Test
-    public void runs_given_body_only_once() {
-        Runnable body = mock(Runnable.class);
+    public void runs_given_body_only_once() throws Throwable {
+        UnsafeBlock body = mock(UnsafeBlock.class);
         BeforeBlock beforeBlock = BeforeBlock.newBeforeAllBlock(body);
 
         beforeBlock.run();
@@ -18,8 +18,8 @@ public class BeforeBlockTest {
     }
 
     @Test
-    public void runs_given_body_on_each_call() {
-        Runnable body = mock(Runnable.class);
+    public void runs_given_body_on_each_call() throws Throwable {
+        UnsafeBlock body = mock(UnsafeBlock.class);
         BeforeBlock beforeBlock = BeforeBlock.newBeforeEachBlock(body);
 
         beforeBlock.run();

--- a/src/test/java/j8spec/DescribeBlockTest.java
+++ b/src/test/java/j8spec/DescribeBlockTest.java
@@ -19,18 +19,16 @@ public class DescribeBlockTest {
 
     private static final String LS = System.getProperty("line.separator");
 
-    private static final Runnable NOOP = () -> {};
-
-    private static final Runnable BEFORE_ALL_BLOCK = () -> {};
-    private static final Runnable BEFORE_EACH_BLOCK = () -> {};
-    private static final Runnable BLOCK_1 = () -> {};
-    private static final Runnable BLOCK_2 = () -> {};
-    private static final Runnable BEFORE_ALL_BLOCK_A = () -> {};
-    private static final Runnable BEFORE_EACH_BLOCK_A = () -> {};
-    private static final Runnable BLOCK_A_1 = () -> {};
-    private static final Runnable BLOCK_A_2 = () -> {};
-    private static final Runnable BLOCK_A_A_1 = () -> {};
-    private static final Runnable BLOCK_A_A_2 = () -> {};
+    private static final UnsafeBlock BEFORE_ALL_BLOCK = () -> {};
+    private static final UnsafeBlock BEFORE_EACH_BLOCK = () -> {};
+    private static final UnsafeBlock BLOCK_1 = () -> {};
+    private static final UnsafeBlock BLOCK_2 = () -> {};
+    private static final UnsafeBlock BEFORE_ALL_BLOCK_A = () -> {};
+    private static final UnsafeBlock BEFORE_EACH_BLOCK_A = () -> {};
+    private static final UnsafeBlock BLOCK_A_1 = () -> {};
+    private static final UnsafeBlock BLOCK_A_2 = () -> {};
+    private static final UnsafeBlock BLOCK_A_A_1 = () -> {};
+    private static final UnsafeBlock BLOCK_A_A_2 = () -> {};
 
     static class SampleSpec {}
 
@@ -142,8 +140,8 @@ public class DescribeBlockTest {
 
     private DescribeBlock aDescribeBlockWithNoBeforeBlocks() {
         Map<String, ItBlockDefinition> itBlocks = new HashMap<>();
-        itBlocks.put("block 1", newItBlockDefinition(NOOP));
-        itBlocks.put("block 2", newItBlockDefinition(NOOP));
+        itBlocks.put("block 1", newItBlockDefinition(UnsafeBlock.NOOP));
+        itBlocks.put("block 2", newItBlockDefinition(UnsafeBlock.NOOP));
 
         DescribeBlock rootDescribeBlock = newRootDescribeBlock(SampleSpec.class, emptyList(), emptyList(), itBlocks);
 

--- a/src/test/java/j8spec/ItBlockTest.java
+++ b/src/test/java/j8spec/ItBlockTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertThat;
 public class ItBlockTest {
 
     @Test
-    public void runs_before_blocks_and_then_body() throws Throwable {
+    public void runs_before_blocks_and_then_block() throws Throwable {
         final List<String> executionOrder = new ArrayList<>();
 
         newItBlock(
@@ -26,12 +26,12 @@ public class ItBlockTest {
                 newBeforeEachBlock(() -> executionOrder.add("beforeEach1")),
                 newBeforeEachBlock(() -> executionOrder.add("beforeEach2"))
             ),
-            () -> executionOrder.add("body")
+            () -> executionOrder.add("block")
         ).tryToExecute();
 
         assertThat(executionOrder.get(0), is("beforeEach1"));
         assertThat(executionOrder.get(1), is("beforeEach2"));
-        assertThat(executionOrder.get(2), is("body"));
+        assertThat(executionOrder.get(2), is("block"));
     }
 
     @Test

--- a/src/test/java/j8spec/ItBlockTest.java
+++ b/src/test/java/j8spec/ItBlockTest.java
@@ -27,7 +27,7 @@ public class ItBlockTest {
                 newBeforeEachBlock(() -> executionOrder.add("beforeEach2"))
             ),
             () -> executionOrder.add("body")
-        ).run();
+        ).tryToExecute();
 
         assertThat(executionOrder.get(0), is("beforeEach1"));
         assertThat(executionOrder.get(1), is("beforeEach2"));

--- a/src/test/java/j8spec/ItBlockTest.java
+++ b/src/test/java/j8spec/ItBlockTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertThat;
 public class ItBlockTest {
 
     @Test
-    public void runs_before_blocks_and_then_body() {
+    public void runs_before_blocks_and_then_body() throws Throwable {
         final List<String> executionOrder = new ArrayList<>();
 
         newItBlock(

--- a/src/test/java/j8spec/J8SpecBeforeAllTest.java
+++ b/src/test/java/j8spec/J8SpecBeforeAllTest.java
@@ -3,18 +3,17 @@ package j8spec;
 import org.junit.Test;
 
 import static j8spec.J8Spec.*;
+import static j8spec.UnsafeBlock.NOOP;
 import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class J8SpecBeforeAllTest {
 
-    private static final Runnable NOOP = () -> {};
-
-    private static final Runnable BEFORE_ALL_0_BLOCK = () -> {};
-    private static final Runnable BEFORE_ALL_1_BLOCK = () -> {};
-    private static final Runnable BEFORE_ALL_A_BLOCK = () -> {};
-    private static final Runnable BEFORE_ALL_AA_BLOCK = () -> {};
+    private static final UnsafeBlock BEFORE_ALL_0_BLOCK = () -> {};
+    private static final UnsafeBlock BEFORE_ALL_1_BLOCK = () -> {};
+    private static final UnsafeBlock BEFORE_ALL_A_BLOCK = () -> {};
+    private static final UnsafeBlock BEFORE_ALL_AA_BLOCK = () -> {};
 
     static class NoBeforeAllSpec {{
         it("block 1", NOOP);

--- a/src/test/java/j8spec/J8SpecBeforeEachTest.java
+++ b/src/test/java/j8spec/J8SpecBeforeEachTest.java
@@ -3,18 +3,17 @@ package j8spec;
 import org.junit.Test;
 
 import static j8spec.J8Spec.*;
+import static j8spec.UnsafeBlock.NOOP;
 import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class J8SpecBeforeEachTest {
 
-    private static final Runnable NOOP = () -> {};
-    
-    private static final Runnable BEFORE_EACH_0_BLOCK = NOOP;
-    private static final Runnable BEFORE_EACH_1_BLOCK = NOOP;
-    private static final Runnable BEFORE_EACH_A_BLOCK = NOOP;
-    private static final Runnable BEFORE_EACH_AA_BLOCK = NOOP;
+    private static final UnsafeBlock BEFORE_EACH_0_BLOCK = () -> {};
+    private static final UnsafeBlock BEFORE_EACH_1_BLOCK = () -> {};
+    private static final UnsafeBlock BEFORE_EACH_A_BLOCK = () -> {};
+    private static final UnsafeBlock BEFORE_EACH_AA_BLOCK = () -> {};
 
     static class NoBeforeEachSpec {{
         it("block 1", NOOP);

--- a/src/test/java/j8spec/J8SpecCIModeTest.java
+++ b/src/test/java/j8spec/J8SpecCIModeTest.java
@@ -5,10 +5,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static j8spec.J8Spec.*;
+import static j8spec.UnsafeBlock.NOOP;
 
 public class J8SpecCIModeTest {
-
-    private static final Runnable NOOP = () -> {};
 
     static class FitSpec {{
         fit("block 1", NOOP);

--- a/src/test/java/j8spec/J8SpecFlowTest.java
+++ b/src/test/java/j8spec/J8SpecFlowTest.java
@@ -40,7 +40,7 @@ public class J8SpecFlowTest {
         log = new ArrayList<>();
         DescribeBlock describeBlock = read(SampleSpec.class);
         for (ItBlock itBlock : describeBlock.flattenItBlocks()) {
-            itBlock.run();
+            itBlock.tryToExecute();
         }
     }
 

--- a/src/test/java/j8spec/J8SpecFlowTest.java
+++ b/src/test/java/j8spec/J8SpecFlowTest.java
@@ -36,10 +36,12 @@ public class J8SpecFlowTest {
     private static List<String> log;
 
     @Before
-    public void resetDescribeBlock() {
+    public void resetDescribeBlock() throws Throwable {
         log = new ArrayList<>();
         DescribeBlock describeBlock = read(SampleSpec.class);
-        describeBlock.flattenItBlocks().forEach(Runnable::run);
+        for (ItBlock itBlock : describeBlock.flattenItBlocks()) {
+            itBlock.run();
+        }
     }
 
     @Test

--- a/src/test/java/j8spec/J8SpecFocusTest.java
+++ b/src/test/java/j8spec/J8SpecFocusTest.java
@@ -8,22 +8,20 @@ import static org.junit.Assert.assertThat;
 
 public class J8SpecFocusTest {
 
-    private static final Runnable NOOP = () -> {};
+    private static final UnsafeBlock IT_BLOCK_1 = () -> {};
+    private static final UnsafeBlock IT_BLOCK_2 = () -> {};
 
-    private static final Runnable IT_BLOCK_1 = () -> {};
-    private static final Runnable IT_BLOCK_2 = () -> {};
-
-    private static final Runnable IT_BLOCK_A1 = () -> {};
-    private static final Runnable IT_BLOCK_A2 = () -> {};
+    private static final UnsafeBlock IT_BLOCK_A1 = () -> {};
+    private static final UnsafeBlock IT_BLOCK_A2 = () -> {};
 
     static class FitBlockOverwrittenSpec {{
-        fit("some text", NOOP);
-        fit("some text", NOOP);
+        fit("some text", UnsafeBlock.NOOP);
+        fit("some text", UnsafeBlock.NOOP);
     }}
 
     static class FitBlockWithCollectorOverwrittenSpec {{
-        fit("some text", c -> c, NOOP);
-        fit("some text", NOOP);
+        fit("some text", c -> c, UnsafeBlock.NOOP);
+        fit("some text", UnsafeBlock.NOOP);
     }}
 
     static class FdescribeSpec {{
@@ -75,22 +73,22 @@ public class J8SpecFocusTest {
 
     @Test(expected = IllegalContextException.class)
     public void does_not_allow_fdescribe_method_direct_invocation() {
-        fdescribe("some text", NOOP);
+        fdescribe("some text", SafeBlock.NOOP);
     }
 
     @Test(expected = IllegalContextException.class)
     public void does_not_allow_fcontext_method_direct_invocation() {
-        fcontext("some text", NOOP);
+        fcontext("some text", SafeBlock.NOOP);
     }
 
     @Test(expected = IllegalContextException.class)
     public void does_not_allow_fit_method_direct_invocation() {
-        fit("some text", NOOP);
+        fit("some text", UnsafeBlock.NOOP);
     }
 
     @Test(expected = IllegalContextException.class)
     public void does_not_allow_fit_method_with_collector_direct_invocation() {
-        fit("some text", c -> c, NOOP);
+        fit("some text", c -> c, UnsafeBlock.NOOP);
     }
 
     @Test(expected = BlockAlreadyDefinedException.class)

--- a/src/test/java/j8spec/J8SpecIgnoreTest.java
+++ b/src/test/java/j8spec/J8SpecIgnoreTest.java
@@ -8,22 +8,20 @@ import static org.junit.Assert.assertThat;
 
 public class J8SpecIgnoreTest {
 
-    private static final Runnable NOOP = () -> {};
+    private static final UnsafeBlock IT_BLOCK_1 = () -> {};
+    private static final UnsafeBlock IT_BLOCK_2 = () -> {};
 
-    private static final Runnable IT_BLOCK_1 = () -> {};
-    private static final Runnable IT_BLOCK_2 = () -> {};
-
-    private static final Runnable IT_BLOCK_A1 = () -> {};
-    private static final Runnable IT_BLOCK_A2 = () -> {};
+    private static final UnsafeBlock IT_BLOCK_A1 = () -> {};
+    private static final UnsafeBlock IT_BLOCK_A2 = () -> {};
 
     static class XitBlockOverwrittenSpec {{
-        xit("some text", NOOP);
-        xit("some text", NOOP);
+        xit("some text", UnsafeBlock.NOOP);
+        xit("some text", UnsafeBlock.NOOP);
     }}
 
     static class XitBlockWithCollectorOverwrittenSpec {{
-        xit("some text", c -> c, NOOP);
-        xit("some text", NOOP);
+        xit("some text", c -> c, UnsafeBlock.NOOP);
+        xit("some text", UnsafeBlock.NOOP);
     }}
 
     static class XdescribeSpec {{
@@ -75,22 +73,22 @@ public class J8SpecIgnoreTest {
 
     @Test(expected = IllegalContextException.class)
     public void does_not_allow_xdescribe_method_direct_invocation() {
-        xdescribe("some text", NOOP);
+        xdescribe("some text", SafeBlock.NOOP);
     }
 
     @Test(expected = IllegalContextException.class)
     public void does_not_allow_xcontext_method_direct_invocation() {
-        xcontext("some text", NOOP);
+        xcontext("some text", SafeBlock.NOOP);
     }
 
     @Test(expected = IllegalContextException.class)
     public void does_not_allow_xit_method_direct_invocation() {
-        xit("some text", NOOP);
+        xit("some text", UnsafeBlock.NOOP);
     }
 
     @Test(expected = IllegalContextException.class)
     public void does_not_allow_xit_method_direct_invocation_with_collector() {
-        xit("some text", c -> c, NOOP);
+        xit("some text", c -> c, UnsafeBlock.NOOP);
     }
 
     @Test(expected = BlockAlreadyDefinedException.class)

--- a/src/test/java/j8spec/J8SpecTest.java
+++ b/src/test/java/j8spec/J8SpecTest.java
@@ -132,16 +132,16 @@ public class J8SpecTest {
     public void builds_a_describe_block_using_it_blocks_from_the_spec_definition() {
         DescribeBlock rootDescribeBlock = read(SampleSpec.class);
 
-        assertThat(rootDescribeBlock.itBlock("block 1").body(), is(IT_BLOCK_1));
-        assertThat(rootDescribeBlock.itBlock("block 2").body(), is(IT_BLOCK_2));
+        assertThat(rootDescribeBlock.itBlock("block 1").block(), is(IT_BLOCK_1));
+        assertThat(rootDescribeBlock.itBlock("block 2").block(), is(IT_BLOCK_2));
 
         DescribeBlock describeA = rootDescribeBlock.describeBlocks().get(0);
-        assertThat(describeA.itBlock("block A.1").body(), is(IT_BLOCK_A1));
-        assertThat(describeA.itBlock("block A.2").body(), is(IT_BLOCK_A2));
+        assertThat(describeA.itBlock("block A.1").block(), is(IT_BLOCK_A1));
+        assertThat(describeA.itBlock("block A.2").block(), is(IT_BLOCK_A2));
 
         DescribeBlock describeAA = describeA.describeBlocks().get(0);
-        assertThat(describeAA.itBlock("block A.A.1").body(), is(IT_BLOCK_AA1));
-        assertThat(describeAA.itBlock("block A.A.2").body(), is(IT_BLOCK_AA2));
+        assertThat(describeAA.itBlock("block A.A.1").block(), is(IT_BLOCK_AA1));
+        assertThat(describeAA.itBlock("block A.A.2").block(), is(IT_BLOCK_AA2));
     }
 
     @Test

--- a/src/test/java/j8spec/J8SpecTest.java
+++ b/src/test/java/j8spec/J8SpecTest.java
@@ -13,19 +13,17 @@ import static org.junit.Assert.assertThat;
 
 public class J8SpecTest {
 
-    private static final Runnable NOOP = () -> {};
+    private static final UnsafeBlock IT_BLOCK_1 = () -> {};
+    private static final UnsafeBlock IT_BLOCK_2 = () -> {};
+    private static final UnsafeBlock IT_BLOCK_3 = () -> {};
 
-    private static final Runnable IT_BLOCK_1 = () -> {};
-    private static final Runnable IT_BLOCK_2 = () -> {};
-    private static final Runnable IT_BLOCK_3 = () -> {};
+    private static final UnsafeBlock IT_BLOCK_A1 = () -> {};
+    private static final UnsafeBlock IT_BLOCK_A2 = () -> {};
 
-    private static final Runnable IT_BLOCK_A1 = () -> {};
-    private static final Runnable IT_BLOCK_A2 = () -> {};
+    private static final UnsafeBlock IT_BLOCK_AA1 = () -> {};
+    private static final UnsafeBlock IT_BLOCK_AA2 = () -> {};
 
-    private static final Runnable IT_BLOCK_AA1 = () -> {};
-    private static final Runnable IT_BLOCK_AA2 = () -> {};
-
-    private static final Runnable IT_BLOCK_B1 = () -> {};
+    private static final UnsafeBlock IT_BLOCK_B1 = () -> {};
 
     static class EmptySpec {}
 
@@ -34,23 +32,23 @@ public class J8SpecTest {
     }
 
     static class ItBlockOverwrittenSpec {{
-        it("some text", NOOP);
-        it("some text", NOOP);
+        it("some text", UnsafeBlock.NOOP);
+        it("some text", UnsafeBlock.NOOP);
     }}
 
     static class DescribeBlockOverwrittenSpec {{
-        describe("some text", NOOP);
-        describe("some text", NOOP);
+        describe("some text", SafeBlock.NOOP);
+        describe("some text", SafeBlock.NOOP);
     }}
 
     static class ContextBlockOverwrittenSpec {{
-        context("some text", NOOP);
-        context("some text", NOOP);
+        context("some text", SafeBlock.NOOP);
+        context("some text", SafeBlock.NOOP);
     }}
 
     static class ItBlockWithCollectorOverwrittenSpec {{
-        it("some text", c -> c, NOOP);
-        it("some text", NOOP);
+        it("some text", c -> c, UnsafeBlock.NOOP);
+        it("some text", UnsafeBlock.NOOP);
     }}
 
     static class ThreadThatSleeps2sSpec {{
@@ -61,7 +59,7 @@ public class J8SpecTest {
                 throw new RuntimeException(e);
             }
 
-            it("block", NOOP);
+            it("block", UnsafeBlock.NOOP);
         });
     }}
 
@@ -162,7 +160,7 @@ public class J8SpecTest {
 
     @Test(expected = IllegalContextException.class)
     public void does_not_allow_describe_method_direct_invocation() {
-        describe("some text", NOOP);
+        describe("some text", SafeBlock.NOOP);
     }
 
     @Test(expected = BlockAlreadyDefinedException.class)
@@ -172,7 +170,7 @@ public class J8SpecTest {
 
     @Test(expected = IllegalContextException.class)
     public void does_not_allow_context_method_direct_invocation() {
-        context("some text", NOOP);
+        context("some text", SafeBlock.NOOP);
     }
 
     @Test(expected = BlockAlreadyDefinedException.class)
@@ -182,12 +180,12 @@ public class J8SpecTest {
 
     @Test(expected = IllegalContextException.class)
     public void does_not_allow_it_method_direct_invocation() {
-        it("some text", NOOP);
+        it("some text", UnsafeBlock.NOOP);
     }
 
     @Test(expected = IllegalContextException.class)
     public void does_not_allow_it_method_direct_invocation_with_collector() {
-        it("some text", c -> c, NOOP);
+        it("some text", c -> c, UnsafeBlock.NOOP);
     }
 
     @Test(expected = BlockAlreadyDefinedException.class)
@@ -203,7 +201,7 @@ public class J8SpecTest {
     @Test(expected = IllegalContextException.class)
     public void forgets_last_spec() {
         read(SampleSpec.class);
-        describe("some text", NOOP);
+        describe("some text", SafeBlock.NOOP);
     }
 
     @Test(expected = IllegalContextException.class)
@@ -213,7 +211,7 @@ public class J8SpecTest {
         } catch (BlockAlreadyDefinedException e) {
         }
 
-        it("some text", NOOP);
+        it("some text", UnsafeBlock.NOOP);
     }
 
     @Test()

--- a/src/test/java/j8spec/junit/J8SpecRunnerTest.java
+++ b/src/test/java/j8spec/junit/J8SpecRunnerTest.java
@@ -27,7 +27,7 @@ public class J8SpecRunnerTest {
     private static final String BLOCK_3 = "block 3";
     private static final String BLOCK_4 = "block 4";
 
-    public static class CustomException extends RuntimeException {}
+    public static class CustomException extends Exception {}
 
     public static class SampleSpec {{
         it(BLOCK_1, newBlock(BLOCK_1));
@@ -116,7 +116,7 @@ public class J8SpecRunnerTest {
 
         runner.runChild(itBlocks.get(0), mock(RunNotifier.class));
 
-        verify(block(BLOCK_1)).run();
+        verify(block(BLOCK_1)).tryToExecute();
     }
 
     @Test
@@ -129,7 +129,7 @@ public class J8SpecRunnerTest {
         runNotifier.addListener(listener);
 
         RuntimeException runtimeException = new RuntimeException();
-        doThrow(runtimeException).when(block(BLOCK_1)).run();
+        doThrow(runtimeException).when(block(BLOCK_1)).tryToExecute();
 
         runner.runChild(itBlocks.get(0), runNotifier);
 
@@ -151,7 +151,7 @@ public class J8SpecRunnerTest {
         assertThat(listener.getDescription(), is(runner.describeChild(itBlocks.get(2))));
         assertThat(listener.isIgnored(), is(true));
 
-        verify(block(BLOCK_3), never()).run();
+        verify(block(BLOCK_3), never()).tryToExecute();
     }
 
     @Test
@@ -184,7 +184,7 @@ public class J8SpecRunnerTest {
     public void notifies_when_a_child_finishes_even_when_it_fails() throws Throwable {
         J8SpecRunner runner = new J8SpecRunner(SampleSpec.class);
         List<ItBlock> itBlocks = runner.getChildren();
-        doThrow(new RuntimeException()).when(block(BLOCK_1)).run();
+        doThrow(new RuntimeException()).when(block(BLOCK_1)).tryToExecute();
         RunNotifier runNotifier = mock(RunNotifier.class);
 
         runner.runChild(itBlocks.get(0), runNotifier);
@@ -198,7 +198,7 @@ public class J8SpecRunnerTest {
         List<ItBlock> itBlocks = runner.getChildren();
 
         RunNotifier runNotifier = mock(RunNotifier.class);
-        doThrow(new CustomException()).when(block(BLOCK_4)).run();
+        doThrow(new CustomException()).when(block(BLOCK_4)).tryToExecute();
 
         runner.runChild(itBlocks.get(3), runNotifier);
 
@@ -225,7 +225,7 @@ public class J8SpecRunnerTest {
         J8SpecRunner runner = new J8SpecRunner(SampleSpec.class);
         List<ItBlock> itBlocks = runner.getChildren();
 
-        doThrow(new RuntimeException()).when(block(BLOCK_4)).run();
+        doThrow(new RuntimeException()).when(block(BLOCK_4)).tryToExecute();
 
         RunNotifier runNotifier = new RunNotifier();
         RunListenerHelper listener = new RunListenerHelper();

--- a/src/test/java/j8spec/junit/J8SpecRunnerTest.java
+++ b/src/test/java/j8spec/junit/J8SpecRunnerTest.java
@@ -1,6 +1,7 @@
 package j8spec.junit;
 
 import j8spec.ItBlock;
+import j8spec.UnsafeBlock;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.Description;
@@ -37,15 +38,15 @@ public class J8SpecRunnerTest {
         describe("describe A", () -> it("block A.1", () -> {}));
     }}
 
-    private static Map<String, Runnable> blocks;
+    private static Map<String, UnsafeBlock> blocks;
 
-    private static Runnable newBlock(String id) {
-        Runnable block = mock(Runnable.class);
+    private static UnsafeBlock newBlock(String id) {
+        UnsafeBlock block = mock(UnsafeBlock.class);
         blocks.put(id, block);
         return block;
     }
 
-    private static Runnable block(String id) {
+    private static UnsafeBlock block(String id) {
         return blocks.get(id);
     }
 
@@ -109,7 +110,7 @@ public class J8SpecRunnerTest {
     }
 
     @Test
-    public void runs_the_given_it_block() throws InitializationError {
+    public void runs_the_given_it_block() throws Throwable {
         J8SpecRunner runner = new J8SpecRunner(SampleSpec.class);
         List<ItBlock> itBlocks = runner.getChildren();
 
@@ -119,7 +120,7 @@ public class J8SpecRunnerTest {
     }
 
     @Test
-    public void notifies_when_a_child_fails() throws InitializationError {
+    public void notifies_when_a_child_fails() throws Throwable {
         J8SpecRunner runner = new J8SpecRunner(SampleSpec.class);
         List<ItBlock> itBlocks = runner.getChildren();
 
@@ -137,7 +138,7 @@ public class J8SpecRunnerTest {
     }
 
     @Test
-    public void notifies_when_a_child_is_ignored() throws InitializationError {
+    public void notifies_when_a_child_is_ignored() throws Throwable {
         J8SpecRunner runner = new J8SpecRunner(SampleSpec.class);
         List<ItBlock> itBlocks = runner.getChildren();
 
@@ -180,7 +181,7 @@ public class J8SpecRunnerTest {
     }
 
     @Test
-    public void notifies_when_a_child_finishes_even_when_it_fails() throws InitializationError {
+    public void notifies_when_a_child_finishes_even_when_it_fails() throws Throwable {
         J8SpecRunner runner = new J8SpecRunner(SampleSpec.class);
         List<ItBlock> itBlocks = runner.getChildren();
         doThrow(new RuntimeException()).when(block(BLOCK_1)).run();
@@ -192,7 +193,7 @@ public class J8SpecRunnerTest {
     }
 
     @Test
-    public void notifies_success_when_expected_exception_occurs() throws InitializationError {
+    public void notifies_success_when_expected_exception_occurs() throws Throwable {
         J8SpecRunner runner = new J8SpecRunner(SampleSpec.class);
         List<ItBlock> itBlocks = runner.getChildren();
 
@@ -220,7 +221,7 @@ public class J8SpecRunnerTest {
     }
 
     @Test
-    public void notifies_failure_when_different_exception_occurs() throws InitializationError {
+    public void notifies_failure_when_different_exception_occurs() throws Throwable {
         J8SpecRunner runner = new J8SpecRunner(SampleSpec.class);
         List<ItBlock> itBlocks = runner.getChildren();
 


### PR DESCRIPTION
Replaces `Runnable` with 2 new functional interfaces: `UnsafeBlock` and `SafeBlock`. Since `UnsafeBlock` is excepted to throw checked exceptions, it will allow the lambda expression to contain code that might throw checked exceptions.

Closes #40.
