### PR TITLE
Upgrade JUnit to 4.13.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 group = 'io.github.j8spec'
-version = '3.1.0-SNAPSHOT'
+version = '3.0.1-SNAPSHOT'
 ext.isReleaseBuild = !version.endsWith("SNAPSHOT")
 
 sourceCompatibility = '1.8'
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    compile     group: 'junit',         name: 'junit',          version: '4.12'
+    compile     group: 'junit',         name: 'junit',          version: '4.13.2'
     testCompile group: 'org.mockito',   name: 'mockito-core',   version: '1.10.19'
 }
 


### PR DESCRIPTION
Due to security vulnerability found in 4.12
(https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250).